### PR TITLE
Create a ProgressiveReader

### DIFF
--- a/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
+++ b/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
@@ -7,14 +7,13 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
 import java.io.InputStream
 
+// TODO: Stop estimating and add a parameter
 const val ESTIMATED_LINEBREAK_SIZE = 1 // assume linux/mac line endings. (\r, \n only)
-/**
- * @param size estimated size of this stream, in bytes.
- */
+
 @ExperimentalCoroutinesApi
-fun InputStream.start(size: Int, scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> {
+fun InputStream.start(scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> {
     return scope.produce {
-        val bufferedReader = bufferedReader()
+        val bufferedReader = this@start.bufferedReader()
         bufferedReader.useLines {
             var bytesRead = 0
             it.forEach { line ->

--- a/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
+++ b/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
@@ -1,0 +1,23 @@
+package com.vutrankien.t9vietnamese
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.channels.toChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import java.io.InputStream
+
+class ProgressiveReader(inputStream: InputStream, size: Int) {
+    @ExperimentalCoroutinesApi
+    fun start(scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> = scope.produce {
+        TODO()
+    }
+
+    data class Progress(val bytesRead: Int, val line: String)
+}

--- a/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
+++ b/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
@@ -3,21 +3,16 @@ package com.vutrankien.t9vietnamese
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
-import kotlinx.coroutines.channels.toChannel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.flow
 import java.io.InputStream
 
-class ProgressiveReader(inputStream: InputStream, size: Int) {
-    @ExperimentalCoroutinesApi
-    fun start(scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> = scope.produce {
-        TODO()
-    }
-
-    data class Progress(val bytesRead: Int, val line: String)
+/**
+ * @param size estimated size of this stream, in bytes.
+ */
+@ExperimentalCoroutinesApi
+fun InputStream.start(size: Int, scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> = scope.produce {
+    TODO()
 }
+
+data class Progress(val bytesRead: Int, val line: String)

--- a/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
+++ b/lib/src/main/java/com/vutrankien/t9vietnamese/ProgressiveReader.kt
@@ -7,12 +7,22 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
 import java.io.InputStream
 
+const val ESTIMATED_LINEBREAK_SIZE = 1 // assume linux/mac line endings. (\r, \n only)
 /**
  * @param size estimated size of this stream, in bytes.
  */
 @ExperimentalCoroutinesApi
-fun InputStream.start(size: Int, scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> = scope.produce {
-    TODO()
+fun InputStream.start(size: Int, scope: CoroutineScope = GlobalScope): ReceiveChannel<Progress> {
+    return scope.produce {
+        val bufferedReader = bufferedReader()
+        bufferedReader.useLines {
+            var bytesRead = 0
+            it.forEach { line ->
+                bytesRead += line.toByteArray().size + ESTIMATED_LINEBREAK_SIZE
+                send(Progress(bytesRead, line))
+            }
+        }
+    }
 }
 
 data class Progress(val bytesRead: Int, val line: String)

--- a/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
+++ b/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
@@ -6,8 +6,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 
 class ProgressiveReaderTests {
     @ExperimentalCoroutinesApi
@@ -15,11 +17,28 @@ class ProgressiveReaderTests {
     fun basicFunction() = runBlocking {
         val content = "a\nb\nc"
         val bytes = content.toByteArray()
-        val progresses = ByteArrayInputStream(bytes).use {
-            it.start(this@runBlocking).toList()
-        }
+        val inputStream = CheckableInputStream(ByteArrayInputStream(bytes))
+        val progresses = inputStream.start(this@runBlocking).toList()
+        assertTrue(inputStream.closed)
         assertEquals(progresses[0], Progress(2, "a"))
         assertEquals(progresses[1], Progress(4, "b"))
         assertEquals(progresses[2], Progress(6, "c"))
+    }
+
+    /**
+     * assert inputStream has closed?
+     */
+    class CheckableInputStream(val delegated: InputStream): InputStream() {
+        var closed = false
+            private set
+
+        override fun read(): Int =
+                delegated.read()
+
+        override fun close() {
+            delegated.close()
+            super.close()
+            closed = true
+        }
     }
 }

--- a/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
+++ b/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
@@ -1,0 +1,25 @@
+package com.vutrankien.t9vietnamese.tests
+
+import com.vutrankien.t9vietnamese.ProgressiveReader
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+class ProgressiveReaderTests {
+    @ExperimentalCoroutinesApi
+    @Test
+    fun basicFunction() = runBlocking {
+        val content = "a\nb\nc"
+        val bytes = content.toByteArray()
+        val progresses = ProgressiveReader(
+            ByteArrayInputStream(bytes),
+            bytes.size
+        ).start(this@runBlocking).toList()
+        assertEquals(progresses[0], ProgressiveReader.Progress(2, "a"))
+        assertEquals(progresses[1], ProgressiveReader.Progress(4, "b"))
+        assertEquals(progresses[2], ProgressiveReader.Progress(5, "c"))
+    }
+}

--- a/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
+++ b/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
@@ -15,9 +15,9 @@ class ProgressiveReaderTests {
     fun basicFunction() = runBlocking {
         val content = "a\nb\nc"
         val bytes = content.toByteArray()
-        val progresses = ByteArrayInputStream(bytes).start(
-                bytes.size,
-                this@runBlocking).toList()
+        val progresses = ByteArrayInputStream(bytes).use {
+            it.start(this@runBlocking).toList()
+        }
         assertEquals(progresses[0], Progress(2, "a"))
         assertEquals(progresses[1], Progress(4, "b"))
         assertEquals(progresses[2], Progress(6, "c"))

--- a/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
+++ b/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
@@ -20,6 +20,6 @@ class ProgressiveReaderTests {
                 this@runBlocking).toList()
         assertEquals(progresses[0], Progress(2, "a"))
         assertEquals(progresses[1], Progress(4, "b"))
-        assertEquals(progresses[2], Progress(5, "c"))
+        assertEquals(progresses[2], Progress(6, "c"))
     }
 }

--- a/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
+++ b/lib/src/test/java/com/vutrankien/t9vietnamese/tests/ProgressiveReaderTests.kt
@@ -1,6 +1,7 @@
 package com.vutrankien.t9vietnamese.tests
 
-import com.vutrankien.t9vietnamese.ProgressiveReader
+import com.vutrankien.t9vietnamese.Progress
+import com.vutrankien.t9vietnamese.start
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.runBlocking
@@ -14,12 +15,11 @@ class ProgressiveReaderTests {
     fun basicFunction() = runBlocking {
         val content = "a\nb\nc"
         val bytes = content.toByteArray()
-        val progresses = ProgressiveReader(
-            ByteArrayInputStream(bytes),
-            bytes.size
-        ).start(this@runBlocking).toList()
-        assertEquals(progresses[0], ProgressiveReader.Progress(2, "a"))
-        assertEquals(progresses[1], ProgressiveReader.Progress(4, "b"))
-        assertEquals(progresses[2], ProgressiveReader.Progress(5, "c"))
+        val progresses = ByteArrayInputStream(bytes).start(
+                bytes.size,
+                this@runBlocking).toList()
+        assertEquals(progresses[0], Progress(2, "a"))
+        assertEquals(progresses[1], Progress(4, "b"))
+        assertEquals(progresses[2], Progress(5, "c"))
     }
 }


### PR DESCRIPTION
We needed the ProgressiveReader for feeding words into the engine, whilst providing progress information which can be used for displaying progress to UI.