### PR TITLE
Include engineSeed preparing time into engine initializing time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,14 +69,14 @@ install:
   - cd ..
 
 # Emulator Management: Create, Start and Wait
-#before_script:
-#  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-#  - emulator -avd test -no-audio -no-window &
-#  - android-wait-for-emulator
-#  - adb shell settings put global window_animation_scale 0 &
-#  - adb shell settings put global transition_animation_scale 0 &
-#  - adb shell settings put global animator_duration_scale 0 &
-#  - adb shell input keyevent 82 &
+before_script:
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell settings put global window_animation_scale 0 &
+  - adb shell settings put global transition_animation_scale 0 &
+  - adb shell settings put global animator_duration_scale 0 &
+  - adb shell input keyevent 82 &
 
 script:
   - |
@@ -93,7 +93,9 @@ script:
   - fold_start app.build "gradle :app:build"
   - ./gradlew -Plint.output.console=true --info :app:build
   - fold_end app.build
-#  - ./gradlew -Plint.output.console=true --info connectedAndroidTest
+  - fold_start app.cAT "gradle :app:connectedAndroidTest"
+  - ./gradlew -Plint.output.console=true --info connectedAndroidTest
+  - fold_end app.cAT
 
 after_failure:
   - export s3key="lib-test/$(git rev-parse --short HEAD)"

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Specifications (Stories):
   1. Confirmed
 
 ### Specs:
-[ ] 1. User should interact with the keypad only.
-        * Keypad-centric accessibility: make use all the key on the keypad, prevent actions outside of the keypad (dialpad).
-[ ] 2. Uppercase should only occur at first letter of words.
-[ ] 3. User should be able to select from a set of displayed candidates.
-[x] 4. When inputting, the possible candidates should be displayed.
-[ ] 5. When confirm button is pressed, the selected candidate should be outputted.
-  [ ] 5.1 If no candidate is being selected then the first candidate will be used.
+1. [ ] User should interact mainly with the keypad (other means of interacting is optionally supported).
+        (Keypad-centric accessibility: make use all the key on the keypad, prevent actions outside of the keypad (dialpad)).
+2. [ ] Uppercase should only occur at first letter of words.
+3. [ ] User should be able to select from a set of displayed candidates.
+4. [x] When inputting, the possible candidates should be displayed.
+5. [ ] When confirm button is pressed, the selected candidate should be outputted.  
+    1. [ ] If no candidate is being selected then the first candidate will be used.
 
 Basic Design:
 ===========

--- a/app/src/main/java/com/vutrankien/t9vietnamese/android/Dagger.kt
+++ b/app/src/main/java/com/vutrankien/t9vietnamese/android/Dagger.kt
@@ -20,24 +20,25 @@ interface ActivityComponent {
 @Module
 class PresenterModule {
     @Provides
-    fun getSeed(): Sequence<String> {
-        val sortedWords = sortedSetOf<String>() // use String's "natural" ordering
-        javaClass.classLoader.getResourceAsStream("vi-DauMoi.dic").bufferedReader().useLines {
-            it.forEach { line ->
-                sortedWords.add(line)
+    fun getSeed(): Lazy<Sequence<String>> {
+        return lazy {
+            val sortedWords = sortedSetOf<String>() // use String's "natural" ordering
+            javaClass.classLoader.getResourceAsStream("vi-DauMoi.dic").bufferedReader().useLines {
+                it.forEach { line ->
+                    sortedWords.add(line)
+                }
             }
+            sortedWords.asSequence()
         }
-        return sortedWords.asSequence()
     }
 
     @Provides
     fun presenter(
-        seed: Sequence<String>,
         engine: T9Engine,
         lg: LogFactory
     ): Presenter {
         engine.pad = VnPad
-        return Presenter(seed, engine, lg)
+        return Presenter(getSeed(), engine, lg)
     }
 }
 

--- a/lib/src/main/java/com/vutrankien/t9vietnamese/lib/Dagger.kt
+++ b/lib/src/main/java/com/vutrankien/t9vietnamese/lib/Dagger.kt
@@ -39,5 +39,5 @@ class PresenterModule(
     fun presenter(
         lg: LogFactory
     ): Presenter =
-        Presenter(engineSeed, engine, lg)
+        Presenter(lazy { engineSeed }, engine, lg)
 }

--- a/lib/src/main/java/com/vutrankien/t9vietnamese/lib/Presenter.kt
+++ b/lib/src/main/java/com/vutrankien/t9vietnamese/lib/Presenter.kt
@@ -4,7 +4,7 @@ import com.vutrankien.t9vietnamese.engine.T9Engine
 import kotlinx.coroutines.launch
 
 class Presenter constructor(
-    private val engineSeed: Sequence<String>,
+    private val engineSeed: Lazy<Sequence<String>>,
     private val engine: T9Engine,
     private val lg: LogFactory
 ) {
@@ -37,7 +37,7 @@ class Presenter constructor(
                     log.i("Start initializing")
                     val startTime = System.currentTimeMillis()
                     view.showProgress()
-                    engine.init(engineSeed)
+                    engine.init(engineSeed.value)
                     view.showKeyboard()
                     val loadTime = (System.currentTimeMillis()
                             - startTime)


### PR DESCRIPTION
The engineSeed calculation should be included in the engine initializing time
Enable CI emulator tests