### PR TITLE
Implement Shift key.

### DIFF
--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/lib/Engine.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/lib/Engine.kt
@@ -16,6 +16,7 @@ class Engine(private val ui: UI, private val trie: Trie) {
     private val fullSequence = StringBuilder(10)
     private var prefixes: Set<String> = emptySet()
     private val prefixesCache= mutableMapOf<String, Set<String>>()
+    var shiftMode: Boolean = false
 
     /*fun type(keySequence: String) {
         keySequence.forEach { k ->
@@ -62,18 +63,18 @@ class Engine(private val ui: UI, private val trie: Trie) {
             return
         }
         if (action == Action.Space) {
-            if (candidates.isNotEmpty()) {
+            if (isComposing()) {
                 // commit current composing word with a space.
                 ui.inputConnection.commitText(candidates.selectedCandidate.text + " ")
             } else {
-                ui.inputConnection.commitText("${Action.Space.symbol}")
+                ui.inputConnection.commitText("${Action.Space.rawChar}")
             }
             reset()
             ui.update(UI.UpdateEvent.UpdateCandidates(candidates))
             return
         }
         if (action == Action.Return) {
-            if (candidates.isNotEmpty()) {
+            if (isComposing()) {
                 // if we're in middle of composing a word, commit without a space.
                 ui.inputConnection.commitText(candidates.selectedCandidate.text)
             } else {
@@ -83,12 +84,23 @@ class Engine(private val ui: UI, private val trie: Trie) {
             ui.update(UI.UpdateEvent.UpdateCandidates(candidates))
             return
         }
-
         if (action == Action.Zero) {
-            fullSequence.append(action.symbol)
+            fullSequence.append(action.rawChar)
             prefixes = emptySet()
             candidates = CandidateSelection.from(listOf(fullSequence.toString()))
             ui.update(UI.UpdateEvent.UpdateCandidates(candidates))
+            return
+        }
+        val _candidates = linkedSetOf<String>()
+        if (action == Action.Shift) {
+            shiftMode = !shiftMode
+            expandPrefixesTo(_candidates)
+            updateCandidateSelection(
+                if (shiftMode)
+                    _candidates.map { it.replaceFirstChar(Char::uppercaseChar) }.toSet()
+                else _candidates,
+                preserveSel = true
+            )
             return
         }
 
@@ -102,10 +114,11 @@ class Engine(private val ui: UI, private val trie: Trie) {
         } else {
             fullSequence.append(action.symbol)
         }
-        val _candidates = linkedSetOf<String>()
         val _prefixes = linkedSetOf<String>()
         // TODO inject subChars
-        val subChars = VNKeys.fromChar(action.symbol).subChars
+        val subChars = VNKeys.fromChar(
+            action.rawChar ?: error("Should be typing action here")
+        ).subChars
         if (fullSequence.length == 1) {
             // Only start searching from 2nd key to prevent too many candidates
             //_candidates.addAll(key.subChars.map { "$it" })
@@ -136,6 +149,11 @@ class Engine(private val ui: UI, private val trie: Trie) {
                 prefixesCache[fullSequence.toString()] = _prefixes
             }
         }
+        expandPrefixesTo(_candidates)
+        updateCandidateSelection(_candidates)
+    }
+
+    private fun expandPrefixesTo(_candidates: LinkedHashSet<String>) {
         prefixes.forEach { pf ->
             if (trie.containsPrefix(pf)) {
                 _candidates.addAll(
@@ -143,23 +161,29 @@ class Engine(private val ui: UI, private val trie: Trie) {
                 )
             }
         }
+    }
+
+    private fun updateCandidateSelection(cands: Set<String>, preserveSel: Boolean = false) {
         candidates = CandidateSelection.from(
-            _candidates
+            cands
                 .groupBy { it.length }
                 .values.flatten()
                 // Put number sequence as the last candidate.
                 .toMutableList().also {
-                  it.add(fullSequence.toString())
-                }
+                    it.add(fullSequence.toString())
+                },
+            if (preserveSel) candidates.selectedCandidateId else 0
         )
         ui.update(UI.UpdateEvent.UpdateCandidates(candidates))
     }
+
+    private fun isComposing() = candidates.isNotEmpty()
 
     private fun reset() {
         prefixes = emptySet()
         candidates = CandidateSelection()
         fullSequence.clear()
-        //selectedCandidateId=0
+        shiftMode = false
     }
 
 }

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/Action.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/Action.kt
@@ -1,11 +1,16 @@
 package com.github.kentvu.t9vietnamese.model
 
-enum class Action(val symbol: Char, ) {
-    Clear('C'),
-    Backspace('⌫'),
-    Star('*'),
-    Hash('#'),
-    Ok('✅'),
+enum class Action(
+    /** null if this is non-typing action, i.e. control action. */
+    val rawChar: Char?,
+    val displayText: String = "", // can't use Char since 🆗 is not accepted by the JVM??
+) {
+    Clear(null, 'C'),
+    Backspace(null, '⌫'),
+    Star(null, '*'),
+    Hash(null, '#'),
+    Shift(null, '⇧'),
+    Ok(null, "🆗"), // ✔,↵,
     One('1'),
     Two('2'),
     Three('3'),
@@ -16,6 +21,10 @@ enum class Action(val symbol: Char, ) {
     Eight('8'),
     Nine('9'),
     Zero('0'),
-    Space(' '),
-    Return('⏎'),
+    Space(' ', '␣'),
+    Return(null, '⏎'),;
+    constructor(rawChar: Char?, displayText: Char)
+            : this(rawChar, "$displayText")
+    val symbol: String
+        get() = displayText.takeIf { it.isNotEmpty() } ?: "$rawChar"
 }

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/CandidateSelection.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/CandidateSelection.kt
@@ -7,8 +7,8 @@ class CandidateSelection(
 ) {
 
     companion object {
-        fun from(candidates: List<String>) =
-            CandidateSelection(candidates.map { Candidate(it) })
+        fun from(candidates: List<String>, selectedCandidateId: Int = 0): CandidateSelection =
+            CandidateSelection(candidates.map { Candidate(it) }, selectedCandidateId)
     }
     //constructor(candidates: Set<String>) :
     //        this(candidates.map { Candidate(it) }.toSet())
@@ -18,7 +18,7 @@ class CandidateSelection(
     val selectedCandidate: Candidate
         get() = candidates[selectedCandidateId]
 
-    fun forEach(action: (Candidate) -> Unit): Unit {
+    fun forEach(action: (Candidate) -> Unit) {
         candidates.forEach { cand -> action(cand) }
     }
 

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/KeyPad.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/KeyPad.kt
@@ -3,7 +3,7 @@ package com.github.kentvu.t9vietnamese.model
 class KeyPad(private val keys: List<Key>) {
     fun findKey(c: Char): Key {
         return keys.firstOrNull { key ->
-            key.action.symbol == c
+            key.action.rawChar == c
         } ?: throw IllegalArgumentException("No key found for $c!")
     }
 

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/VNKeys.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/VNKeys.kt
@@ -6,11 +6,11 @@ enum class VNKeys(
     override val subChars: String,
     override val longAction: Action? = null
 ) : Key {
-    Clear(Action.Clear, ""),//.apply { sym2Key[action.symbol] = this }
-    keyBackspace(Action.Backspace, ""),//.apply { sym2Key[action.symbol] = this }
-    keyStar(Action.Star, "⏎",Action.Return),//.apply { sym2Key[action.symbol] = this }
-    keyHash(Action.Hash, ""),//.apply { sym2Key[action.symbol] = this }
-    keyOk(Action.Ok, ""),//.apply { sym2Key[action.symbol] = this } // ✔,↵,🆗 is not accepted by the JVM??
+    Shift(Action.Shift, ""),//.apply { sym2Key[action.symbol] = this }
+    keyBackspace(Action.Backspace, "C", Action.Clear),//.apply { sym2Key[action.symbol] = this }
+    keyStar(Action.Star, ""),//.apply { sym2Key[action.symbol] = this }
+    keyHash(Action.Hash, "⏎", Action.Return),//.apply { sym2Key[action.symbol] = this }
+    keyOk(Action.Ok, ""),//.apply { sym2Key[action.symbol] = this }
     key1(Action.One, ".,?"),//.apply { sym2Key[action.symbol] = this }
     key2(Action.Two, "aăâbć"),//.apply { sym2Key[action.symbol] = this }
     key3(Action.Three, "dđef̀ê"),//.apply { sym2Key[action.symbol] = this }
@@ -24,7 +24,7 @@ enum class VNKeys(
     ;
     companion object {
         private val sym2Key =
-            entries.associateBy { it.action.symbol }
+            entries.associateBy { it.action.rawChar /*symbol.first()*/ }
         fun fromChar(c: Char): Key {
             return sym2Key[c] ?: throw IllegalArgumentException("No Key for char '$c'.")
         }

--- a/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/AppUI.kt
+++ b/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/AppUI.kt
@@ -32,6 +32,7 @@ import com.github.kentvu.lib.logging.Logger
 import com.github.kentvu.t9vietnamese.UI
 import com.github.kentvu.t9vietnamese.KeypadEvent
 import com.github.kentvu.t9vietnamese.lib.InputConnection
+import com.github.kentvu.t9vietnamese.model.Action
 import com.github.kentvu.t9vietnamese.model.CandidateSelection
 import com.github.kentvu.t9vietnamese.model.Key
 import com.github.kentvu.t9vietnamese.model.VNKeys
@@ -121,7 +122,7 @@ abstract class AppUI(
         log.debug("$keyEvent")
         if (keyEvent.type == KeyEventType.KeyUp) {
             if (keyEvent.isCtrlPressed && keyEvent.key == ComposeKey.C) {
-                eventSource.tryEmit(KeypadEvent.KeyPress(Clear.action))
+                eventSource.tryEmit(KeypadEvent.KeyPress(Action.Clear))
             }
             if (Letter2Keypad.available(keyEvent.key)) {
                 eventSource.tryEmit(
@@ -239,7 +240,7 @@ abstract class AppUI(
                 horizontalAlignment = Alignment.End,
             ) {
                 with(VNKeys) {
-                    KeyboardRow(onKeyClick, keysEnabled, Clear, keyOk, keyBackspace)
+                    KeyboardRow(onKeyClick, keysEnabled, Shift, keyOk, keyBackspace)
                     KeyboardRow(onKeyClick, keysEnabled, key1, key2, key3)
                     KeyboardRow(onKeyClick, keysEnabled, key4, key5, key6)
                     KeyboardRow(onKeyClick, keysEnabled, key7, key8, key9)
@@ -292,14 +293,14 @@ abstract class AppUI(
                 .padding(1.dp)
                 .weight(1F)
             for (key in keys) {
-                ComposableKey(key, mod, keysEnabled, onKeyClick)
+                ComposeKey(key, mod, keysEnabled, onKeyClick)
             }
         }
     }
 
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
-    private fun ComposableKey(
+    private fun ComposeKey(
         key: Key,
         modifier: Modifier,
         keysEnabled: Boolean,
@@ -311,16 +312,24 @@ abstract class AppUI(
             modifier = modifier,/*.semantics { text = buildAnnotatedString { append(key.symbol) } }*/
             enabled = keysEnabled
         ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Column(
+                //Modifier.fillMaxWidth(0.8f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
                 Text(
-                    "${key.action.symbol}",
-                    style = MaterialTheme.typography.titleLarge
+                    key.action.symbol,
+                    style = MaterialTheme.typography.bodyLarge
                 )
                 Text(
-                    key.subChars,
+                    key.subChars/*if (key.action.type == Control)*/,
                     style = MaterialTheme.typography.bodySmall
                 )
             }
+            /*Text(
+                "↓",
+                Modifier.align(Alignment.CenterStart),
+                Color.LightGray
+            )*/
         }
     }
 

--- a/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/LongPressButton.kt
+++ b/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/LongPressButton.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ripple.rememberRipple


### PR DESCRIPTION
- Current candidate list capitalization toggled.
- Separated displaying text with key's symbol (typing char), displayText is String so as to allow multi-byte emojis like Dokomo's OK symbol.
- rearranged Key Clear make space for Shift key.