### PR TITLE
Guide user to enable this IM.

### DIFF
--- a/app/src/androidMain/kotlin/com/github/kentvu/t9vietnamese/android/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/github/kentvu/t9vietnamese/android/MainActivity.kt
@@ -1,28 +1,36 @@
 package com.github.kentvu.t9vietnamese.android
 
+import android.content.Intent
+import android.inputmethodservice.InputMethodService
 import android.os.Bundle
+import android.provider.Settings
 import android.view.KeyEvent
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
 import com.github.kentvu.lib.logging.Logger
 import com.github.kentvu.lib.logging.NapierLogger
-import com.github.kentvu.t9vietnamese.UI
-import com.github.kentvu.t9vietnamese.ui.ComposeUI
 import com.github.kentvu.t9vietnamese.T9App
-import com.github.kentvu.t9vietnamese.android.AndroidEnvironmentInteraction
-import com.github.kentvu.t9vietnamese.ui.T9UI
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.github.kentvu.t9vietnamese.ui.AndroidUI
 
 class MainActivity : ComponentActivity() {
 
     private val ui by lazy {
-        T9UI(
+        AndroidUI(
             lifecycleScope,
-        ) { finish() }
+            close = { finish() },
+            launchSystemImSettings = {
+                startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+            },
+            launchImePicker = {
+                getSystemService(InputMethodManager::class.java)
+                    .showInputMethodPicker()
+            },
+        )
     }
     private val app by lazy {
-        T9App/*.create*/(
+        T9App(
             AndroidEnvironmentInteraction(this),
             lifecycleScope,
             ui,

--- a/app/src/androidMain/kotlin/com/github/kentvu/t9vietnamese/android/T9Vietnamese.kt
+++ b/app/src/androidMain/kotlin/com/github/kentvu/t9vietnamese/android/T9Vietnamese.kt
@@ -26,14 +26,7 @@ class T9Vietnamese : InputMethodService() {
     private val ui by lazy {
         ImeServiceUI(
             scope,
-        ) { /*finish()*/ }
-    }
-    private val app by lazy {
-        T9App(
-            AndroidEnvironmentInteraction(this),
-            scope,
-            ui,
-            object: InputSystemConnection {
+            inputConnection = object : InputSystemConnection {
                 override fun commitText(text: String) {
                     currentInputConnection.commitText(text, 0)
                 }
@@ -45,7 +38,14 @@ class T9Vietnamese : InputMethodService() {
                 override fun performEditorAction() {
                     currentInputConnection.performEditorAction(currentInputEditorInfo.actionId)
                 }
-            }
+            },
+        )
+    }
+    private val app by lazy {
+        T9App(
+            AndroidEnvironmentInteraction(this),
+            scope,
+            ui,
         )
     }
 

--- a/app/src/androidMain/res/xml/method.xml
+++ b/app/src/androidMain/res/xml/method.xml
@@ -22,6 +22,7 @@
 
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
     android:supportsSwitchingToNextInputMethod="true"
+    android:settingsActivity="com.github.kentvu.t9vietnamese.android.MainActivity"
     >
     <!--    <subtype
             android:label="@string/label_subtype_en_US"

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/Backend.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/Backend.kt
@@ -9,10 +9,9 @@ import com.github.kentvu.t9vietnamese.model.Trie
 class Backend(
     private val trie: Trie,
     private val ui: UI,
-    inputConnection: InputSystemConnection,
 ) {
     private var initialized: Boolean = false
-    private val engine = Engine(ui, trie, inputConnection)
+    private val engine = Engine(ui, trie)
 
     fun init() {
         trie.load()

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/T9App.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/T9App.kt
@@ -13,7 +13,6 @@ class T9App(
     protected val env: EnvironmentInteraction,
     protected val scope: CoroutineScope = CoroutineScope(env.mainDispatcher + Job()),
     val ui: UI,
-    private val inputConnection: InputSystemConnection = DefaultInputConnection(ui),
 ) {
 
     private val backend = Backend(
@@ -22,7 +21,6 @@ class T9App(
             env.fileSystem
         ),
         ui,
-        inputConnection,
     )
 
     fun start() {
@@ -34,40 +32,6 @@ class T9App(
     fun stop() {
     }
 
-    companion object {
-        /*fun create(
-            env: EnvironmentInteraction,
-            scope: CoroutineScope = CoroutineScope(env.mainDispatcher + Job()),
-            stateSource: MutableStateFlow<UI.State> = MutableStateFlow(UI.State { }),
-            ui: UI,
-        ): T9App {
-            return T9App(env, scope, stateSource, ui).also {
-                ui.init(stateSource)
-            }
-        }*/
-    }
-
-    class DefaultInputConnection(
-        private val ui: UI,
-    ): InputSystemConnection {
-        override fun commitText(text: String) {
-            ui.update { copy(
-                confirmedText = confirmedText + text
-            )}
-        }
-
-        override fun deleteSurroundingText(beforeLength: Int, afterLength: Int) {
-            ui.update { copy(
-                confirmedText = confirmedText.dropLast(1)
-            ) }
-        }
-
-        override fun performEditorAction() {
-            log.info("TODO(performEditorAction)")
-        }
-        companion object {
-            private val log = Logger.tag("DefaultInputConnection")
-        }
-    }
+    companion object
 
 }

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/UI.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/UI.kt
@@ -1,9 +1,12 @@
 package com.github.kentvu.t9vietnamese
 
+import com.github.kentvu.t9vietnamese.lib.InputSystemConnection
 import com.github.kentvu.t9vietnamese.model.CandidateSelection
 
 //abstract class UI(private val state: State) {
 interface UI {
+
+    val inputConnection: InputSystemConnection
 
     fun update(manipulator: State.() -> State)
 
@@ -14,7 +17,6 @@ interface UI {
         // SelectNextCandidate : UpdateEvent()
 
         val candidates: CandidateSelection = CandidateSelection(),
-        val confirmedText: String = "",
         //https://slackhq.github.io/circuit/states-and-events/
         val keypadEventSink : ((KeypadEvent) -> Unit)
     )

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/lib/Engine.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/lib/Engine.kt
@@ -17,14 +17,13 @@ import kotlin.text.map
 class Engine(
     private val ui: UI,
     private val trie: Trie,
-    private val inputConnection: InputSystemConnection,
 ) {
-    var candidates: CandidateSelection = CandidateSelection()
-        private set
+    private val inputConnection: InputSystemConnection = ui.inputConnection
+    private var candidates: CandidateSelection = CandidateSelection()
     private val fullSequence = StringBuilder(10)
     private var prefixes: Set<String> = emptySet()
     private val prefixesCache= mutableMapOf<String, Set<String>>()
-    var shiftMode: Boolean = false
+    private var shiftMode: Boolean = false
 
     /*fun type(keySequence: String) {
         keySequence.forEach { k ->
@@ -100,11 +99,11 @@ class Engine(
             return
         }
         if (action == Action.One) {
-            fullSequence.append(Action.One.rawChar)
             if (isComposing()) {
                 inputConnection.commitText(candidates.selectedCandidate.text)
                 reset()
             }
+            fullSequence.append(Action.One.rawChar)
             candidates = CandidateSelection.from(
                 buildList {
                     addAll(

--- a/common/ui/src/androidMain/kotlin/com/github/kentvu/t9vietnamese/ui/AppUiPreview.kt
+++ b/common/ui/src/androidMain/kotlin/com/github/kentvu/t9vietnamese/ui/AppUiPreview.kt
@@ -1,37 +1,35 @@
 package com.github.kentvu.t9vietnamese.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import com.github.kentvu.t9vietnamese.KeypadEvent
-import com.github.kentvu.t9vietnamese.T9App
 import com.github.kentvu.t9vietnamese.UI
-import com.github.kentvu.t9vietnamese.lib.EnvironmentInteraction
 import com.github.kentvu.t9vietnamese.model.CandidateSelection
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import okio.FileSystem
-import okio.Source
 
 @Preview
 @Composable
 fun AppPreview() {
-    val ui = T9UI(
+    val ui = remember { AndroidUI(
         CoroutineScope(Dispatchers.Default),
         MutableStateFlow(
             UI.State(
                 initialized = true,
                 candidates = CandidateSelection.from(listOf("aa", "cc", "dd")),
-                confirmedText = "Test UI"
             ) { ev ->
                 when (ev) {
                     is KeypadEvent.CandidateSelect -> TODO()
                     KeypadEvent.CloseRequest -> TODO()
                     is KeypadEvent.KeyPress -> TODO()
                 }
-            }),
-        {}
-    )
+              }
+        ),
+        close = {},
+        launchSystemImSettings = {},
+        launchImePicker = {},
+    ) }
     ui.AppUi()
 }

--- a/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/AndroidUI.kt
+++ b/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/AndroidUI.kt
@@ -1,0 +1,233 @@
+package com.github.kentvu.t9vietnamese.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.github.kentvu.lib.logging.Logger
+import com.github.kentvu.t9vietnamese.KeypadEvent
+import com.github.kentvu.t9vietnamese.UI
+import com.github.kentvu.t9vietnamese.lib.InputSystemConnection
+import com.github.kentvu.t9vietnamese.model.Action
+import com.github.kentvu.t9vietnamese.model.VNKeys
+import com.github.kentvu.t9vietnamese.ui.ComposeUI.Companion.isCtrlQ
+import com.github.kentvu.t9vietnamese.ui.theme.T9VietnameseTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class AndroidUI(
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+    private val stateSource: MutableStateFlow<UI.State> = MutableStateFlow(UI.State {}),
+    private val _ic: InputConnection = InputConnection(),
+    private val close: () -> Unit,
+    private val launchSystemImSettings: () -> Unit,
+    private val launchImePicker: () -> Unit,
+) : ComposeUI by ImeServiceUI(scope, stateSource, _ic) {
+
+    private val keyEventSource = MutableSharedFlow<KeyEvent>(extraBufferCapacity = 1)
+    //override val inputConnection = InputConnection()
+
+    fun onKeyEvent(keyEvent: KeyEvent): Boolean {
+        return keyEventSource.tryEmit(keyEvent)
+    }
+
+    /** Translates [KeyEvent] to [Action] */
+    private fun handleKeyEvent(
+        keyEvent: KeyEvent,
+        state: UI.State,
+    ) {
+        if (keyEvent.isCtrlQ()) {
+            state.keypadEventSink(KeypadEvent.CloseRequest)
+        } else {
+            //onUserEvent(keyEvent, state)
+            log.debug("$keyEvent")
+            if (keyEvent.type == KeyEventType.KeyUp) {
+                if (keyEvent.isCtrlPressed && keyEvent.key == Key.C) {
+                    state.keypadEventSink(KeypadEvent.KeyPress(Action.Clear))
+                }
+                if (Letter2Keypad.available(keyEvent.key)) {
+                    state.keypadEventSink(
+                        KeypadEvent.KeyPress(
+                            VNKeys.fromChar(
+                                Letter2Keypad.numForKey(keyEvent.key)!!
+                            ).action
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    object Letter2Keypad {
+        @OptIn(ExperimentalComposeUiApi::class)
+        private val map = mapOf(
+            Key.Zero to '0',
+            Key.One to '1',
+            Key.Two to '2',
+            Key.Three to '3',
+            Key.Four to '4',
+            Key.Five to '5',
+            Key.Six to '6',
+            Key.Seven to '7',
+            Key.Eight to '8',
+            Key.Nine to '9',
+            // Next is for simulating a keypad by left-side of the keyboard.
+            Key.Spacebar to '0',
+            Key.Q to '1',
+            Key.W to '2',
+            Key.E to '3',
+            Key.A to '4',
+            Key.S to '5',
+            Key.D to '6',
+            Key.Z to '7',
+            Key.X to '8',
+            Key.C to '9',
+            Key.Semicolon to '*',
+            Key.Backspace to '⌫',
+        )
+
+        fun available(key: Key): Boolean {
+            return map.containsKey(key)
+        }
+
+        fun numForKey(key: Key): Char? {
+            return map[key]
+        }
+
+    }
+
+    /** Fake InputConnection for demonstrating this IM's functions. */
+    class InputConnection(): InputSystemConnection {
+        var confirmedText by mutableStateOf("")
+        override fun commitText(text: String) {
+            confirmedText = confirmedText + text
+        }
+
+        override fun deleteSurroundingText(beforeLength: Int, afterLength: Int) {
+            confirmedText = confirmedText.dropLast(1)
+        }
+
+        override fun performEditorAction() {
+            log.info("TODO(performEditorAction)")
+        }
+        companion object {
+            private val log = Logger.tag("DefaultInputConnection")
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun AppUi() {
+        val state by stateSource.collectAsState()
+        T9VietnameseTheme {
+            Scaffold(topBar = {
+                TopAppBar(title = {
+                    Text("T9Vietnamese")
+                })
+            }) { innerPadding ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Bottom,
+                    modifier = Modifier.fillMaxSize().padding(innerPadding)
+                ) {
+                    GuideUserUI(/*Modifier.weight(1f)*/)
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.weight(1f).padding(top = 4.dp)
+                    ) {
+                        val confirmedText = _ic.confirmedText
+                        TextField(
+                            value = confirmedText,
+                            modifier = Modifier.semantics {
+                                contentDescription = ComposeUI.Semantic.testOutput
+                            },
+                            onValueChange = { _ic.confirmedText = it }
+                        )
+                        val clipboardManager = LocalClipboardManager.current
+                        Button({
+                            clipboardManager.setText(
+                                AnnotatedString(
+                                    confirmedText
+                                )
+                            )
+                        }) {
+                            Text("Copy")
+                        }
+                    }
+                    CandidateView(state,)
+                    ImeUI(state, Modifier)
+                }
+            }
+        }
+        if (state.closed) {
+            close()
+            return
+        }
+        LaunchedEffect(state) {
+            keyEventSource/*.onEach { onUserEvent(it) }.filter { it.isCtrlQ() }*/.collect {
+                handleKeyEvent(it, state)
+            }
+        }
+    }
+
+    @Composable
+    private fun /*ColumnScope.*/GuideUserUI(
+        modifier: Modifier = Modifier,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier.fillMaxWidth(),
+        ) {
+            Text("Please enable T9Vietnamese:", Modifier.align(Alignment.Start))
+            Button(
+                { launchSystemImSettings() },
+                Modifier.align(Alignment.Start)
+            ) {
+                Text("open system im settings")
+            }
+            Text("You can choose T9Vietnamese as default IM:", Modifier.align(Alignment.Start))
+            Button(
+                { launchImePicker() },
+                Modifier.align(Alignment.Start)
+            ) {
+                Text("Launch IME picker")
+            }
+        }
+    }
+
+    companion object {
+        private val log = Logger.tag("AppUI")
+
+    }
+}

--- a/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/ComposeUI.kt
+++ b/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/ComposeUI.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
@@ -36,12 +37,15 @@ import com.github.kentvu.lib.logging.Logger
 import com.github.kentvu.t9vietnamese.UI
 import com.github.kentvu.t9vietnamese.KeypadEvent
 import com.github.kentvu.t9vietnamese.UI.State
+import com.github.kentvu.t9vietnamese.lib.InputSystemConnection
 import com.github.kentvu.t9vietnamese.model.Action
 import com.github.kentvu.t9vietnamese.model.CandidateSelection
 import com.github.kentvu.t9vietnamese.model.Key
 import com.github.kentvu.t9vietnamese.model.NumericSubstitution
 import com.github.kentvu.t9vietnamese.model.VNKeys
 import com.github.kentvu.t9vietnamese.model.VNKeys.*
+import com.github.kentvu.t9vietnamese.ui.ComposeUI.Companion.isCtrlQ
+import com.github.kentvu.t9vietnamese.ui.ComposeUI.Semantic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -49,281 +53,11 @@ import kotlinx.coroutines.flow.update
 import androidx.compose.ui.input.key.Key as ComposeKey
 
 interface ComposeUI: UI {
-    @Composable
-    fun AppUi()
 
     @Composable
     fun ImeUI(state: State, modifier: Modifier = Modifier)
     @Composable
     fun CandidateView(state: State)
-}
-
-class T9UI(
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
-    private val stateSource: MutableStateFlow<State> = MutableStateFlow(State {}),
-    private val close: () -> Unit,
-) : ComposeUI {
-
-    private val keyEventSource = MutableSharedFlow<KeyEvent>(extraBufferCapacity = 1)
-
-    override fun update(manipulator: State.() -> State) {
-        this.stateSource.update { it.manipulator() }
-    }
-
-    fun onKeyEvent(keyEvent: KeyEvent): Boolean {
-        return keyEventSource.tryEmit(keyEvent)
-    }
-
-    /** Translates [KeyEvent] to [Action] */
-    private fun handleKeyEvent(
-        keyEvent: KeyEvent,
-        state: State,
-    ) {
-        if (keyEvent.isCtrlQ()) {
-            state.keypadEventSink(KeypadEvent.CloseRequest)
-        } else {
-            //onUserEvent(keyEvent, state)
-            log.debug("$keyEvent")
-            if (keyEvent.type == KeyEventType.KeyUp) {
-                if (keyEvent.isCtrlPressed && keyEvent.key == ComposeKey.C) {
-                    state.keypadEventSink(KeypadEvent.KeyPress(Action.Clear))
-                }
-                if (Letter2Keypad.available(keyEvent.key)) {
-                    state.keypadEventSink(
-                        KeypadEvent.KeyPress(
-                            VNKeys.fromChar(
-                                Letter2Keypad.numForKey(keyEvent.key)!!
-                            ).action
-                        )
-                    )
-                }
-            }
-        }
-    }
-
-    object Letter2Keypad {
-        @OptIn(ExperimentalComposeUiApi::class)
-        private val map = mapOf(
-            ComposeKey.Zero to '0',
-            ComposeKey.One to '1',
-            ComposeKey.Two to '2',
-            ComposeKey.Three to '3',
-            ComposeKey.Four to '4',
-            ComposeKey.Five to '5',
-            ComposeKey.Six to '6',
-            ComposeKey.Seven to '7',
-            ComposeKey.Eight to '8',
-            ComposeKey.Nine to '9',
-            // Next is for simulating a keypad by left-side of the keyboard.
-            ComposeKey.Spacebar to '0',
-            ComposeKey.Q to '1',
-            ComposeKey.W to '2',
-            ComposeKey.E to '3',
-            ComposeKey.A to '4',
-            ComposeKey.S to '5',
-            ComposeKey.D to '6',
-            ComposeKey.Z to '7',
-            ComposeKey.X to '8',
-            ComposeKey.C to '9',
-            ComposeKey.Semicolon to '*',
-            ComposeKey.Backspace to '⌫',
-        )
-
-        fun available(key: ComposeKey): Boolean {
-            return map.containsKey(key)
-        }
-
-        fun numForKey(key: ComposeKey): Char? {
-            return map[key]
-        }
-
-    }
-
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    override fun AppUi() {
-        val state by stateSource.collectAsState()
-        //TODO use T9Theme
-        MaterialTheme {
-            Scaffold(topBar = {
-                TopAppBar(title = {
-                    Text("T9Vietnamese")
-                })
-            }) { innerPadding ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Bottom,
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    var confirmedText by remember { mutableStateOf("") }
-                    TextField(
-                        value = confirmedText,
-                        modifier = Modifier.semantics { contentDescription=Semantic.testOutput },
-                        onValueChange = { confirmedText = it }
-                    )
-                    val clipboardManager = LocalClipboardManager.current
-                    Button({clipboardManager.setText(AnnotatedString(confirmedText))}) {
-                        Text("Copy")
-                    }
-                    CandidateView(state,)
-                    ImeUI(state, Modifier.padding(innerPadding))
-                }
-            }
-        }
-        if (state.closed) {
-            close()
-            return
-        }
-        LaunchedEffect(state) {
-            keyEventSource/*.onEach { onUserEvent(it) }.filter { it.isCtrlQ() }*/.collect {
-                handleKeyEvent(it, state)
-            }
-        }
-    }
-
-    @Composable
-    override fun ImeUI(state: State, modifier: Modifier) {
-        Keypad(
-            modifier,
-            state.initialized
-        ) { key, isLong ->
-            if (isLong) {
-                if (key.longAction != null)
-                    state.keypadEventSink(
-                        KeypadEvent.KeyPress(key.longAction!!)
-                    )
-            } else state.keypadEventSink(
-                KeypadEvent.KeyPress(key.action)
-            )
-        }
-    }
-
-    @Composable
-    override fun CandidateView(state: State) {
-        CandidatesView(state.candidates) {
-            state.keypadEventSink(KeypadEvent.CandidateSelect(it))
-        }
-    }
-
-    @Composable
-    fun Keypad(
-        modifier: Modifier = Modifier,
-        keysEnabled: Boolean,
-        onKeyClick: (key: Key, isLong: Boolean) -> Unit,
-    ) {
-        //Napier.d("Recompose ${getThreadId()}")
-        Surface(
-            shape = MaterialTheme.shapes.medium,
-            //color = MaterialTheme.colors.secondary,
-            modifier = modifier
-                .animateContentSize()
-                .padding(1.dp)
-        ) {
-            Column(
-                verticalArrangement = Arrangement.Bottom,
-                horizontalAlignment = Alignment.End,
-            ) {
-                with(VNKeys) {
-                    KeyboardRow(onKeyClick, keysEnabled, Shift, keyOk, keyBackspace)
-                    KeyboardRow(onKeyClick, keysEnabled, key1, key2, key3)
-                    KeyboardRow(onKeyClick, keysEnabled, key4, key5, key6)
-                    KeyboardRow(onKeyClick, keysEnabled, key7, key8, key9)
-                    KeyboardRow(onKeyClick, keysEnabled, keyStar, key0, keyHash)
-                }
-            }
-        }
-    }
-
-    @Composable
-    protected fun CandidatesView(candidates: CandidateSelection, onItemSelected: (Int) -> Unit) {
-        val state = rememberLazyListState(candidates.selectedCandidateId)
-        LazyRow(
-            modifier = Modifier.semantics {
-                contentDescription = Semantic.candidates
-            }.background(Color.LightGray),
-            state = state
-        ) {
-            candidates.forEachIndexed { i, cand ->
-                item(cand.text) {
-                    Text(
-                        cand.text,
-                        Modifier.padding(start = 4.dp)
-                            .run {
-                                if (candidates.selectedCandidate == cand)
-                                    semantics {
-                                        contentDescription = Semantic.selectedCandidate
-                                    }.background(Color.Gray)
-                                else clickable { onItemSelected(i) }
-                            }
-                    )
-                }
-            }
-        }
-        if (state.layoutInfo.visibleItemsInfo.isNotEmpty())
-        if ((candidates.selectedCandidateId >= state.layoutInfo.visibleItemsInfo.last().index) ||
-            (candidates.selectedCandidateId <= state.layoutInfo.visibleItemsInfo.first().index)) //firstVisibleItemIndex
-            LaunchedEffect(candidates) {
-                state.scrollToItem(candidates.selectedCandidateId)
-            }
-    }
-
-    @Composable
-    private fun KeyboardRow(
-        onKeyClick: (key: Key, isLong: Boolean) -> Unit,
-        keysEnabled: Boolean,
-        vararg keys: Key
-    ) {
-        Row {
-            val mod = Modifier
-                .padding(1.dp)
-                .weight(1F)
-            for (key in keys) {
-                ComposableKey(key, mod, keysEnabled, onKeyClick)
-            }
-        }
-    }
-
-    @OptIn(ExperimentalFoundationApi::class)
-    @Composable
-    private fun ComposableKey(
-        key: Key,
-        modifier: Modifier,
-        keysEnabled: Boolean,
-        onKeyClick: (key: Key, isLong: Boolean) -> Unit,
-    ) {
-        Button(
-            onClick = { onKeyClick(key, false) },
-            onLongClick = { onKeyClick(key, true) },
-            modifier = modifier,/*.semantics { text = buildAnnotatedString { append(key.symbol) } }*/
-            enabled = keysEnabled
-        ) {
-            Column(
-                //Modifier.fillMaxWidth(0.8f),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    key.action.symbol,
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                val rawChar = key.action.rawChar
-                Text(
-                    if (key.longAction != null) {
-                        key.longAction!!.symbol
-                    } else if (rawChar != null) { /*if (key.action.type == Control)*/
-                        if (rawChar.isDigit()) {
-                            NumericSubstitution.VN.forNum(rawChar)
-                        } else "$rawChar"
-                    } else "",
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
-            /*Text(
-                "↓",
-                Modifier.align(Alignment.CenterStart),
-                Color.LightGray
-            )*/
-        }
-    }
 
     object Semantic {
         const val candidates = "Candidates"
@@ -332,11 +66,9 @@ class T9UI(
     }
 
     companion object {
-        private val log = Logger.tag("AppUI")
 
-        private fun KeyEvent.isCtrlQ(): Boolean {
+        fun KeyEvent.isCtrlQ(): Boolean {
             return type == KeyEventType.KeyUp && isCtrlPressed && key == ComposeKey.Q
         }
-
     }
 }

--- a/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/ImeServiceUI.kt
+++ b/common/ui/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/ui/ImeServiceUI.kt
@@ -1,20 +1,52 @@
 package com.github.kentvu.t9vietnamese.ui
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.github.kentvu.t9vietnamese.KeypadEvent
 import com.github.kentvu.t9vietnamese.UI.State
+import com.github.kentvu.t9vietnamese.lib.InputSystemConnection
+import com.github.kentvu.t9vietnamese.model.Action
+import com.github.kentvu.t9vietnamese.model.CandidateSelection
+import com.github.kentvu.t9vietnamese.model.Key
+import com.github.kentvu.t9vietnamese.model.NumericSubstitution
+import com.github.kentvu.t9vietnamese.model.VNKeys
+import com.github.kentvu.t9vietnamese.model.VNKeys.*
+import com.github.kentvu.t9vietnamese.ui.ComposeUI.Semantic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 
 class ImeServiceUI(
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     private val stateSource: MutableStateFlow<State> = MutableStateFlow(State {}),
-    private val close: () -> Unit,
-) : ComposeUI by T9UI(scope, stateSource, close) {
+    override val inputConnection: InputSystemConnection,
+) : ComposeUI {
+
+    override fun update(manipulator: State.() -> State) {
+        this.stateSource.update { it.manipulator() }
+    }
 
     @Composable
     fun ImeUI() {
@@ -26,5 +58,149 @@ class ImeServiceUI(
     fun CandidateView() {
         val state by stateSource.collectAsState()
         CandidateView(state)
+    }
+
+    @Composable
+    override fun ImeUI(state: State, modifier: Modifier) {
+        Keypad(
+            modifier,
+            state.initialized
+        ) { key, isLong ->
+            if (isLong) {
+                if (key.longAction != null)
+                    state.keypadEventSink(
+                        KeypadEvent.KeyPress(key.longAction!!)
+                    )
+            } else state.keypadEventSink(
+                KeypadEvent.KeyPress(key.action)
+            )
+        }
+    }
+
+    @Composable
+    fun Keypad(
+        modifier: Modifier = Modifier,
+        keysEnabled: Boolean,
+        onKeyClick: (key: Key, isLong: Boolean) -> Unit,
+    ) {
+        //Napier.d("Recompose ${getThreadId()}")
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            //color = MaterialTheme.colors.secondary,
+            modifier = modifier
+                .animateContentSize()
+                .padding(1.dp)
+        ) {
+            Column(
+                verticalArrangement = Arrangement.Bottom,
+                horizontalAlignment = Alignment.End,
+            ) {
+                with(VNKeys) {
+                    KeyboardRow(onKeyClick, keysEnabled, Shift, keyOk, keyBackspace)
+                    KeyboardRow(onKeyClick, keysEnabled, key1, key2, key3)
+                    KeyboardRow(onKeyClick, keysEnabled, key4, key5, key6)
+                    KeyboardRow(onKeyClick, keysEnabled, key7, key8, key9)
+                    KeyboardRow(onKeyClick, keysEnabled, keyStar, key0, keyHash)
+                }
+            }
+        }
+    }
+
+    @Composable
+    override fun CandidateView(state: State) {
+        CandidatesView(state.candidates) {
+            state.keypadEventSink(KeypadEvent.CandidateSelect(it))
+        }
+    }
+
+    @Composable
+    protected fun CandidatesView(candidates: CandidateSelection, onItemSelected: (Int) -> Unit) {
+        val state = rememberLazyListState(candidates.selectedCandidateId)
+        LazyRow(
+            modifier = Modifier.semantics {
+                contentDescription = Semantic.candidates
+            }.background(Color.LightGray),
+            state = state
+        ) {
+            candidates.forEachIndexed { i, cand ->
+                item(cand.text) {
+                    Text(
+                        cand.text,
+                        Modifier.padding(start = 4.dp)
+                            .run {
+                                if (candidates.selectedCandidate == cand)
+                                    semantics {
+                                        contentDescription = Semantic.selectedCandidate
+                                    }.background(Color.Gray)
+                                else clickable { onItemSelected(i) }
+                            }
+                    )
+                }
+            }
+        }
+        if (state.layoutInfo.visibleItemsInfo.isNotEmpty())
+        if ((candidates.selectedCandidateId >= state.layoutInfo.visibleItemsInfo.last().index) ||
+            (candidates.selectedCandidateId <= state.layoutInfo.visibleItemsInfo.first().index)) //firstVisibleItemIndex
+            LaunchedEffect(candidates) {
+                state.scrollToItem(candidates.selectedCandidateId)
+            }
+    }
+
+    @Composable
+    private fun KeyboardRow(
+        onKeyClick: (key: Key, isLong: Boolean) -> Unit,
+        keysEnabled: Boolean,
+        vararg keys: Key
+    ) {
+        Row {
+            val mod = Modifier
+                .padding(1.dp)
+                .weight(1F)
+            for (key in keys) {
+                ComposableKey(key, mod, keysEnabled, onKeyClick)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    private fun ComposableKey(
+        key: Key,
+        modifier: Modifier,
+        keysEnabled: Boolean,
+        onKeyClick: (key: Key, isLong: Boolean) -> Unit,
+    ) {
+        Button(
+            onClick = { onKeyClick(key, false) },
+            onLongClick = { onKeyClick(key, true) },
+            modifier = modifier,/*.semantics { text = buildAnnotatedString { append(key.symbol) } }*/
+            enabled = keysEnabled
+        ) {
+            Column(
+                //Modifier.fillMaxWidth(0.8f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    key.action.symbol,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                val rawChar = key.action.rawChar
+                Text(
+                    if (key.longAction != null) {
+                        key.longAction!!.symbol
+                    } else if (rawChar != null) { /*if (key.action.type == Control)*/
+                        if (rawChar.isDigit()) {
+                            NumericSubstitution.VN.forNum(rawChar)
+                        } else "$rawChar"
+                    } else "",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+            /*Text(
+                "↓",
+                Modifier.align(Alignment.CenterStart),
+                Color.LightGray
+            )*/
+        }
     }
 }


### PR DESCRIPTION
- Make ImeServiceUI primary implementation of ComposeUI, and AppUI (now AndroidUI) is decoration of ImeServiceUI (using kotlin's interface delegation) 
- Temporary set settings destination to MainActivity (From system's settings App) 
- Fix a crash if Backspace is pressed right after 1. 
- Move AppUI out of ComposeUI and rename to AndroidUI (Maybe system IM settings is navigatable only on Android?)