### PR TITLE
Fixes type2_candidatesContainsSingleLetterOnly()

### DIFF
--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/lib/Engine.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/lib/Engine.kt
@@ -175,9 +175,7 @@ class Engine(
                 updateCandidateSelection(getPunctuationMarks())
             }
             return
-            // pass through
         }
-        val _candidates = linkedSetOf<String>()
         if (action == Action.Shift) {
             shiftMode = !shiftMode
             if (isComposing()) {
@@ -211,14 +209,17 @@ class Engine(
         val subChars = keyPad.numericSubstitution(action)
         if (fullSequence.length == 1) {
             // Only start searching from 2nd key to prevent too many candidates
+            val _candidates = linkedSetOf<String>()
             subChars.map { "$it" }.forEach { c ->
-              if (trie.containsPrefix(c)) {
-                  _candidates.add(c)
-                  _prefixes.add(c)
-              }
-          }
+                if (trie.containsPrefix(c)) {
+                    _candidates.add(c)
+                    _prefixes.add(c)
+                }
+            }
             prefixes = _prefixes
             prefixesCache[fullSequence.toString()] = _prefixes
+            updateCandidateSelection(_candidates)
+            return
         } else {
             prefixes.forEach { pf ->
                 subChars.forEach { sc ->

--- a/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/CandidateSelection.kt
+++ b/common/src/commonMain/kotlin/com/github/kentvu/t9vietnamese/model/CandidateSelection.kt
@@ -1,10 +1,11 @@
 package com.github.kentvu.t9vietnamese.model
 
 
+/** Impl. Collection for inheriting isEmpty and forEach etc. */
 class CandidateSelection(
     private val candidates: List<Candidate>,
     val selectedCandidateId: Int = 0
-): Iterable<Candidate> by candidates {
+): Collection<Candidate> by candidates {
 
     companion object {
         fun from(candidates: List<String>, selectedCandidateId: Int = 0): CandidateSelection =
@@ -37,7 +38,6 @@ class CandidateSelection(
         )
     }
 
-    fun isNotEmpty() = candidates.isNotEmpty()
     fun select(id: Int): CandidateSelection {
         return CandidateSelection(candidates, id)
     }

--- a/common/src/commonTest/kotlin/com/github/kentvu/t9vietnamese/T9AppTest.kt
+++ b/common/src/commonTest/kotlin/com/github/kentvu/t9vietnamese/T9AppTest.kt
@@ -14,6 +14,8 @@ import okio.ByteString.Companion.toByteString
 import okio.FileSystem
 import okio.Source
 import okio.fakefilesystem.FakeFileSystem
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import t9vietnamese.common.generated.resources.Res
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -49,10 +51,10 @@ class T9AppTest {
         override val ioDispatcher: CoroutineDispatcher
             get() = Dispatchers.Default
         override val fileSystem: FileSystem = FakeFileSystem()
-        override val vnWordsSource: Flow<Result<Source>>
-            get() = flowOf(Result.success(Buffer().write("test\ntis".encodeUtf8())))
-        override val vnTrieSource: Flow<Result<Source>>
-            get() = TODO("Not yet implemented")
 
+        @OptIn(ExperimentalResourceApi::class)
+        override suspend fun readVnTrie(): ByteArray {
+            return Res.readBytes("files/vi-DauMoi.dawg")
+        }
     }
 }

--- a/common/ui/src/commonTest/kotlin/com/github/kentvu/t9vietnamese/ui/test/AppRunner.kt
+++ b/common/ui/src/commonTest/kotlin/com/github/kentvu/t9vietnamese/ui/test/AppRunner.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.filterToOne
@@ -87,12 +89,14 @@ class AppRunner {
   }
 
   fun ComposeUiTest.candidatesAllMatches(regex: Regex) {
-    assertTrue(
-      onCandidates().also { it.printToLog("candidatesContain") }.onChildren().fetchSemanticsNodes()
-        .all { sn ->
-          sn.config[SemanticsProperties.Text].any { regex.matches(it) }
-        }, "Not all candidate matches $regex"
-    )
+    candidatesAllMatches(SemanticsMatcher("${SemanticsProperties.Text.name} matches $regex",) { node ->
+      node.config[SemanticsProperties.Text].any { regex.matches(it) }
+    })
+  }
+
+  fun ComposeUiTest.candidatesAllMatches(matcher: SemanticsMatcher) {
+    onCandidates().also { it.printToLog("candidatesContain") }
+      .onChildren().assertAll(matcher)
   }
 
   companion object {

--- a/common/ui/src/commonTest/kotlin/com/github/kentvu/t9vietnamese/ui/test/T9AppEndToEndTest.kt
+++ b/common/ui/src/commonTest/kotlin/com/github/kentvu/t9vietnamese/ui/test/T9AppEndToEndTest.kt
@@ -1,6 +1,8 @@
 package com.github.kentvu.t9vietnamese.ui.test
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
 import kotlin.text.Regex
@@ -31,8 +33,12 @@ class T9AppEndToEndTest {
     with(runner) {
       startApp()
       type("2")
-      candidatesAllMatches(Regex("^\\w$"))
+      candidatesAllMatches(textHasLength1)
     }
+  }
+
+  private val textHasLength1 = SemanticsMatcher("${SemanticsProperties.Text.name} has length 1",) { node ->
+    node.config[SemanticsProperties.Text].any { it.length == 1 }
   }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ android-targetSdk = "34"
 
 compose-multiplatform = "1.7.3" # https://github.com/JetBrains/compose-multiplatform/releases
 compose-ui = "1.7.8" # https://developer.android.com/jetpack/androidx/releases/compose-ui
+#uiTestAndroid = "1.8.2"
 
 coroutines = "1.10.1" # https://github.com/Kotlin/kotlinx.coroutines
 coroutines-test = "1.10.1" # https://github.com/Kotlin/kotlinx.coroutines

--- a/webDemo/src/jsMain/kotlin/com/github/kentvu/t9vietnamese/web/BrowserUI.kt
+++ b/webDemo/src/jsMain/kotlin/com/github/kentvu/t9vietnamese/web/BrowserUI.kt
@@ -16,6 +16,7 @@ import org.jetbrains.compose.web.dom.A
 import org.jetbrains.compose.web.dom.Button
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.I
+import org.jetbrains.compose.web.dom.Li
 import org.jetbrains.compose.web.dom.Small
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
@@ -72,6 +73,10 @@ class BrowserUI(
       Div({ classes("candidates") }) {
         Ul({ classes("list-group", "list-group-horizontal") }) {
           val candidates = state.candidates
+          if (candidates.isEmpty())
+            Li({classes("list-group-item", "disabled")}){
+              Text("Please type...")
+            }
           candidates.forEachIndexed { i, candidate ->
             A("#", {
               onClick {

--- a/webDemo/src/jsMain/kotlin/com/github/kentvu/t9vietnamese/web/Main.kt
+++ b/webDemo/src/jsMain/kotlin/com/github/kentvu/t9vietnamese/web/Main.kt
@@ -36,7 +36,6 @@ fun main() {
     app.start()
   }
   renderComposable(rootElementId = "root") {
-    LaunchedEffect(app) { }
     Main {
       Div({ classes("container", "py-5") }) {
         H2({ classes("pb-2", "px-4", "border-bottom") }) {


### PR DESCRIPTION
The test is failing: 
```
java.lang.AssertionError: Not all candidate matches ^\w$
	at org.junit.Assert.fail(Assert.java:89)
	at kotlin.test.junit.JUnitAsserter.fail(JUnitSupport.kt:56)
	at kotlin.test.Asserter$DefaultImpls.assertTrue(Assertions.kt:694)
	at kotlin.test.junit.JUnitAsserter.assertTrue(JUnitSupport.kt:30)
	at kotlin.test.Asserter$DefaultImpls.assertTrue(Assertions.kt:704)
	at kotlin.test.junit.JUnitAsserter.assertTrue(JUnitSupport.kt:30)
	at kotlin.test.AssertionsKt__AssertionsKt.assertTrue(Assertions.kt:44)
	at kotlin.test.AssertionsKt.assertTrue(Unknown Source)
	at com.github.kentvu.t9vietnamese.ui.test.AppRunner.candidatesAllMatches(AppRunner.kt:91)
	at com.github.kentvu.t9vietnamese.ui.test.T9AppEndToEndTest.type2_candidatesContainsSingleLetterOnly
```