### PR TITLE
Fixing #68

### DIFF
--- a/.github/workflows/android-deploygate.yml
+++ b/.github/workflows/android-deploygate.yml
@@ -11,6 +11,14 @@ on:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+
+    env:
+      # Enable these for signing with custom key.
+      DEBUG_KEYSTORE: "${{ github.workspace }}/debug.keystore"
+      DEBUG_KEYSTORE_PASSWORD: android
+      DEBUG_KEY_ALIAS: androiddebugkey
+      DEBUG_KEY_PASSWORD: android
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,13 +44,24 @@ jobs:
                   echo "Restoring debug keystore from GitHub secrets"
                   mkdir -pv ~/.android
                   gpg -d --passphrase "debug0" --batch "debug.keystore.asc" > ~/.android/debug.keystore
+                  cp -lv ~/.android/debug.keystore $DEBUG_KEYSTORE
               fi
           fi
 
       - name: UI Test
         run: ./gradlew :common:jvmTest :common:ui:jvmTest
 
-      - name: Build Release Bundle
+      - name: Persist test result
+        uses: actions/upload-artifact@v4
+        with:
+          name: vietnamese-t9-ime-test-result
+          path: | #webDemo/build/test-results/
+            common/build/test-results/
+            common/build/reports/tests/jvmTest/
+            common/ui/build/test-results/
+            common/ui/build/reports/tests/jvmTest/
+
+      - name: Build Debug Bundle
         run: ./gradlew :app:bundleDebug
 
       - name: Upload AAB to DeployGate
@@ -59,3 +78,12 @@ jobs:
             Branch: ${{ github.head_ref }}
             Commit: ${{ github.sha }}
 
+      - name: Build Debug APK
+        run: ./gradlew :app:assembleDebug
+
+      - name: Upload Debug APK
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: t9-ime-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Fixing #68

I assumed `gradle :assembleDebug` will pick up `~/.android/debug.keystore` for signing, but (maybe) that was wrong?

Other changes:
- Upload APK and test-result to run artifacts.